### PR TITLE
Loft App gets its own directory

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,5 +3,11 @@ APP_NAME: str = 'loft'
 HOST: str = '0.0.0.0'
 PORT: int = 2402
 
-# folder where files uploaded on the web client are downloaded to
-DOWNLOADS_FOLDER: str = '~/Downloads'
+# working directory for the app (maybe make hidden in the future)
+APP_FOLDER: str = '~/loftApp'
+
+# folder where files received to the host from the client go
+RECEIVED_FOLDER: str = '~/loftApp/received'
+
+# folder where files to send to the client from the host go
+SEND_FOLDER: str = '~/loftApp/send'

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -3,11 +3,8 @@ APP_NAME: str = 'loft'
 HOST: str = '0.0.0.0'
 PORT: int = 2402
 
-# working directory for the app (maybe make hidden in the future)
-APP_FOLDER: str = '~/loftApp'
-
 # folder where files received to the host from the client go
-RECEIVED_FOLDER: str = '~/loftApp/received'
+RECEIVE_FOLDER: str = '~/Loft/receive'
 
 # folder where files to send to the client from the host go
-SEND_FOLDER: str = '~/loftApp/send'
+SEND_FOLDER: str = '~/Loft/send'

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,21 +1,21 @@
 
 import os
 
-from __init__ import APP_NAME, APP_FOLDER, RECEIVED_FOLDER, HOST, PORT
+from __init__ import APP_NAME, SEND_FOLDER, RECEIVE_FOLDER, HOST, PORT
 from ui import Gui
 
-APP_FOLDER = os.path.expanduser(APP_FOLDER)
-RECEIVED_FOLDER = os.path.expanduser(RECEIVED_FOLDER)
+SEND_FOLDER = os.path.expanduser(SEND_FOLDER)
+RECEIVE_FOLDER = os.path.expanduser(RECEIVE_FOLDER)
 
 def main():
     '''Entry point for the application.'''
-    if not os.path.exists(APP_FOLDER):
-        os.mkdir(APP_FOLDER)
+    if not os.path.exists(SEND_FOLDER):
+        os.makedirs(SEND_FOLDER, exist_ok=True)
 
-    if not os.path.exists(RECEIVED_FOLDER):
-        os.mkdir(RECEIVED_FOLDER)
+    if not os.path.exists(RECEIVE_FOLDER):
+        os.makedirs(RECEIVE_FOLDER, exist_ok=True)
 
-    gui = Gui(APP_NAME, HOST, PORT, {'received_folder': RECEIVED_FOLDER})
+    gui = Gui(APP_NAME, HOST, PORT, {'receive_folder': RECEIVE_FOLDER})
     gui.run_and_exit()
 
 

--- a/src/__main__.py
+++ b/src/__main__.py
@@ -1,18 +1,21 @@
 
 import os
 
-from __init__ import APP_NAME, DOWNLOADS_FOLDER, HOST, PORT
+from __init__ import APP_NAME, APP_FOLDER, RECEIVED_FOLDER, HOST, PORT
 from ui import Gui
 
-
-DOWNLOADS_FOLDER = os.path.expanduser(DOWNLOADS_FOLDER)
+APP_FOLDER = os.path.expanduser(APP_FOLDER)
+RECEIVED_FOLDER = os.path.expanduser(RECEIVED_FOLDER)
 
 def main():
     '''Entry point for the application.'''
-    if not os.path.exists(DOWNLOADS_FOLDER):
-        os.mkdir(DOWNLOADS_FOLDER)
+    if not os.path.exists(APP_FOLDER):
+        os.mkdir(APP_FOLDER)
 
-    gui = Gui(APP_NAME, HOST, PORT, {'downloads_folder': DOWNLOADS_FOLDER})
+    if not os.path.exists(RECEIVED_FOLDER):
+        os.mkdir(RECEIVED_FOLDER)
+
+    gui = Gui(APP_NAME, HOST, PORT, {'received_folder': RECEIVED_FOLDER})
     gui.run_and_exit()
 
 

--- a/src/web/blueprints/landing.py
+++ b/src/web/blueprints/landing.py
@@ -31,6 +31,6 @@ def upload_file():
 
         filename = secure_filename(file.filename)
         file.save(os.path.join(
-            current_app.config['downloads_folder'], filename))
+            current_app.config['received_folder'], filename))
 
     return render_template('pages/index.html')

--- a/src/web/blueprints/landing.py
+++ b/src/web/blueprints/landing.py
@@ -31,6 +31,6 @@ def upload_file():
 
         filename = secure_filename(file.filename)
         file.save(os.path.join(
-            current_app.config['received_folder'], filename))
+            current_app.config['receive_folder'], filename))
 
     return render_template('pages/index.html')


### PR DESCRIPTION
- creates and uses a dedicated folder for loft functions
- doesn't touch user's downloads folder (I noticed it overwriting a file with the same name that I previously uploaded for testing)
- adds ~/loftApp/received and ~/loftApp/send

- Simplifies issue #33 (show uploaded files), just show files in ~/loftApp/received
- Simplifies issue #14 (show files being served), just display files in ~/loftApp/send
- maybe we can symlink files selected to be sent into the send folder

To test, perform upload and navigate to ~/loftApp/received

closes #34 