### PR TITLE
Fix send client to host not updating selected file - Add cache_timeout

### DIFF
--- a/src/web/blueprints/landing.py
+++ b/src/web/blueprints/landing.py
@@ -42,7 +42,7 @@ def create_blueprint(send_name_path):
         file_path = send_name_path['file_path']
 
         try:
-            return send_from_directory(file_path, file_name, as_attachment=True)
+            return send_from_directory(file_path, file_name, as_attachment=True, cache_timeout=0)
         except FileNotFoundError:
             abort(404)
     


### PR DESCRIPTION
Before: Sending a file from the host to the client sends a file that was previously sent in the past instead of the file selected by the user.

After fix: Sending a file from the host to the client sends the file currently selected by the user.

Adds the cache_timeout=0 to send_file_from_directory so that the file doesn't remain cached.